### PR TITLE
Add a button to populate with ranks from the official campaign via NadeoLiveServices.

### DIFF
--- a/CampaignPoints/API.as
+++ b/CampaignPoints/API.as
@@ -1,0 +1,46 @@
+namespace API {
+
+    void GetCurrentCampaignRanks() {
+        if (!NadeoServices::IsAuthenticated("NadeoLiveServices")) {
+            return;
+        }
+
+        auto reqCampaign = NadeoServices::Get("NadeoLiveServices", NadeoServices::BaseURLLive()+"/api/token/campaign/official?length=1&offset=0");
+        reqCampaign.Start();
+        while (!reqCampaign.Finished()) {
+            yield();
+        }
+        auto resCampaign = Json::Parse(reqCampaign.String());
+        auto currentCampaign = resCampaign["campaignList"][0];
+        string currentCampaignGroupId = currentCampaign["leaderboardGroupUid"];
+        auto mapList = currentCampaign["playlist"];
+        for (int i = 0; i < mapList.Length; ++i) {
+            auto map = mapList[i];
+            string mapUid = map["mapUid"];
+            int rank = GetRank(currentCampaignGroupId, mapUid);
+            int index = map["position"];
+            if (rank > 0 && index >= 0 && index < inputRanks.Length) {
+                inputRanks[index] = rank;
+            }
+        }
+    }
+
+    int GetRank(string groupUid, string mapUid) {
+        string reqRanksUrl = NadeoServices::BaseURLLive()+"/api/token/leaderboard/group/"+groupUid+"/map/"+mapUid+"?accountId="+NadeoServices::GetAccountID();
+        auto reqRanks = NadeoServices::Get("NadeoLiveServices", reqRanksUrl);
+        reqRanks.Start();
+        while (!reqRanks.Finished()) {
+            yield();
+        }
+        auto resRanks = Json::Parse(reqRanks.String());
+        auto zones = resRanks["zones"];
+        for (int i = 0; i < zones.Length; ++i) {
+            auto zone = zones[i];
+            if (zone["zoneName"] == "World") {
+                return zone["ranking"]["position"];
+            }
+        }
+        return -1;
+    }
+
+}

--- a/CampaignPoints/Main.as
+++ b/CampaignPoints/Main.as
@@ -37,7 +37,7 @@ void RenderInterface() {
     if (!ShowWindow) return;
     if (UI::Begin(WindowTitle, ShowWindow, UI::WindowFlags::NoCollapse | UI::WindowFlags::NoResize)) {
         
-        UI::SetWindowSize(vec2(770, 910)); 
+        UI::SetWindowSize(vec2(770, 930)); 
 
         for (int i = 0; i < inputRanks.Length; i++) {
             int mapNum = i+1;
@@ -65,6 +65,9 @@ void RenderInterface() {
         }
         if (UI::Button("Set All Above 10 to 10")) {
             SetValuesAboveThreshold(10);
+        }
+        if (UI::Button("Set all to official campaign")) {
+            SetValuesToOfficialCampaign();
         }
     
     
@@ -106,6 +109,10 @@ void SetValuesAboveThreshold(int threshold) {
         }
     }  // Update map texts after setting values
     CalculateTotalPoints();  // Recalculate the total points
+}
+
+void SetValuesToOfficialCampaign() {
+    startnew(API::GetCurrentCampaignRanks);
 }
 
 int CalculateResult(int rank) {

--- a/CampaignPoints/info.toml
+++ b/CampaignPoints/info.toml
@@ -1,5 +1,9 @@
 [meta]
-name     = "Campaign Points Calculator"
-author   = "Aflac_ducko"
+name = "Campaign Points Calculator"
+author = "Aflac_ducko"
 category = "Test"
-version  = "1.1.0"
+version = "1.1.0"
+siteid = 611
+
+[script]
+dependencies = ["NadeoServices"]


### PR DESCRIPTION
This assumes you want ranks to be populated from the official campaign. It could probably be updated to work for any campaign, or the campaign the user currently has open.

The requests are made synchronously, which takes a few seconds. The requests could be made in parallel, but you'll need to work around getting data to and from coroutines.

This doesn't really have any error checking.