### PR TITLE
Handle fetching ranks for maps with no rank

### DIFF
--- a/CampaignPoints/API.as
+++ b/CampaignPoints/API.as
@@ -16,12 +16,13 @@ namespace API {
         auto mapList = currentCampaign["playlist"];
         for (int i = 0; i < mapList.Length; ++i) {
             auto map = mapList[i];
+            int index = map["position"];
+            if (index < 0 || index >= inputRanks.Length) {
+                continue;
+            }
             string mapUid = map["mapUid"];
             int rank = GetRank(currentCampaignGroupId, mapUid);
-            int index = map["position"];
-            if (rank > 0 && index >= 0 && index < inputRanks.Length) {
-                inputRanks[index] = rank;
-            }
+            inputRanks[index] = rank;
         }
         loadingTimes = false;
     }
@@ -33,7 +34,13 @@ namespace API {
         while (!reqRanks.Finished()) {
             yield();
         }
+
         auto resRanks = Json::Parse(reqRanks.String());
+        if (!resRanks.HasKey("zones")) {
+            // No rank for this map.
+            return 0;
+        }
+
         auto zones = resRanks["zones"];
         for (int i = 0; i < zones.Length; ++i) {
             auto zone = zones[i];
@@ -41,7 +48,7 @@ namespace API {
                 return zone["ranking"]["position"];
             }
         }
-        return -1;
+        return 0;
     }
 
 }

--- a/CampaignPoints/Main.as
+++ b/CampaignPoints/Main.as
@@ -86,7 +86,7 @@ void CalculateTotalPoints() {
     bool validInput = true;
 
     for (int i = 0; i < inputRanks.Length; i++) {
-        if (inputRanks[i] < 1) {
+        if (inputRanks[i] < 0) {
             validInput = false;
             break;
         }
@@ -116,7 +116,9 @@ void SetValuesToOfficialCampaign() {
 }
 
 int CalculateResult(int rank) {
-    if (rank < 11) {
+    if (rank < 1) {
+        return 0;
+    } else if (rank < 11) {
         return 40000 / rank;
     } else {
         return int((4000 / Math::Pow(2, Math::Ceil(Math::Log(rank) / Math::Log(10)) - 1)) * (Math::Pow(10, Math::Ceil(Math::Log(rank) / Math::Log(10)) - 1) / rank + 0.9));

--- a/CampaignPoints/info.toml
+++ b/CampaignPoints/info.toml
@@ -2,7 +2,7 @@
 name = "Campaign Points Calculator"
 author = "Aflac_ducko, Benjyman"
 category = "Test"
-version = "1.2.0"
+version = "1.2.1"
 siteid = 611
 
 [script]


### PR DESCRIPTION
I noticed that the plugin crashed calculating my score on the new campaign because I have not played all the maps yet. I updated the plugin to set the score and rank to 0 for maps that have not been played.